### PR TITLE
allow for anonymous map generation using boolean outSorceMap flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ module.exports = function(source, inputSourceMap) {
 
     var opts = this.options['uglify-loader'] || {};
     // just an indicator to generate source maps, the output result.map will be modified anyway
-    opts.outSourceMap = "out.map.js";
+    // tell UglifyJS2 not to emit a name by just setting outSourceMap to true
+    opts.outSourceMap = true;
     opts.fromString = true;
 
     var result = UglifyJS.minify(source, opts);


### PR DESCRIPTION
This PR could be merged in after [this PR](https://github.com/mishoo/UglifyJS2/pull/786) is integrated into https://github.com/mishoo/UglifyJS2 to suppress the output of dummy file names.
That way the generated file could easily be processed further using the https://github.com/webpack/source-map-loader.
I am using this for a two-step build process from a single webpack instance that generates a development version fast (using uglify-loader to pre-compress individual files) and a production version on top of that in a second step that may take some time (using uglify plugin).
