### PR TITLE
webpack 2 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = function(source, inputSourceMap) {
         this.cacheable();
     }
 
-    var opts = this.options['uglify-loader'] || {};
+    var opts = loaderUtils.parseQuery(this.query) || {};
     // just an indicator to generate source maps, the output result.map will be modified anyway
     // tell UglifyJS2 not to emit a name by just setting outSourceMap to true
     opts.outSourceMap = true;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/bestander/uglify-loader",
   "dependencies": {
-    "loader-utils": "^0.2.7",
-    "uglify-js": "^2.4.16"
+    "loader-utils": "^0.2.16",
+    "uglify-js": "^2.7.5"
   }
 }


### PR DESCRIPTION
Webpack 2 insists on passing options through the `query` interface.