### PR TITLE
Handle inputSourceMap for Full Source Maps

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,48 @@
 var UglifyJS = require("uglify-js");
 var loaderUtils = require('loader-utils');
+var sourceMap = require('source-map');
+
+function mergeSourceMap(map, inputMap) {
+  var inputMapConsumer = new sourceMap.SourceMapConsumer(inputMap);
+  var outputMapConsumer = new sourceMap.SourceMapConsumer(map);
+
+  var mergedGenerator = new sourceMap.SourceMapGenerator({
+    file: inputMapConsumer.file,
+    sourceRoot: inputMapConsumer.sourceRoot
+  });
+
+  var source = outputMapConsumer.sources[0];
+
+  inputMapConsumer.eachMapping(function (mapping) {
+    var generatedPosition = outputMapConsumer.generatedPositionFor({
+      line: mapping.generatedLine,
+      column: mapping.generatedColumn,
+      source: source
+    });
+    if (generatedPosition.column != null) {
+      mergedGenerator.addMapping({
+        source: mapping.source,
+
+        original: mapping.source == null ? null : {
+          line: mapping.originalLine,
+          column: mapping.originalColumn
+        },
+
+        generated: generatedPosition
+      });
+    }
+  });
+
+  var mergedMap = mergedGenerator.toJSON();
+  inputMap.mappings = mergedMap.mappings;
+  return inputMap
+};
 
 module.exports = function(source, inputSourceMap) {
     var callback = this.async();
 
     if (this.cacheable) {
-        this.cacheable();
+      this.cacheable();
     }
 
     var opts = this.options['uglify-loader'] || {};
@@ -15,13 +52,17 @@ module.exports = function(source, inputSourceMap) {
     opts.fromString = true;
 
     var result = UglifyJS.minify(source, opts);
-
-    var sourceFilename = loaderUtils.getRemainingRequest(this);
-    var current = loaderUtils.getCurrentRequest(this);
     var sourceMap = JSON.parse(result.map);
-    sourceMap.sources = [sourceFilename];
-    sourceMap.file = current;
-    sourceMap.sourcesContent = [source];
 
-    callback(null, result.code, sourceMap);
+    if (inputSourceMap) {
+      callback(null, result.code, mergeSourceMap(sourceMap, inputSourceMap));
+    } else {
+      var sourceFilename = loaderUtils.getRemainingRequest(this);
+      var current = loaderUtils.getCurrentRequest(this);
+      sourceMap.sources = [sourceFilename];
+      sourceMap.file = current;
+      sourceMap.sourcesContent = [source];
+
+      callback(null, result.code, sourceMap);
+    }
 };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/bestander/uglify-loader",
   "dependencies": {
     "loader-utils": "^0.2.7",
+    "source-map": "^0.5.6",
     "uglify-js": "^2.4.16"
   }
 }


### PR DESCRIPTION
Fixes #10 

This change makes sure to handle the `inputSourceMap` parameter to the Webpack loader so that if a previous source map was present, they are merged. This is applicable for example if a file was configured to be piped through the `['uglifier', 'babel']` loaders to ensure the source map show the original source, and not the babel compiled output.