### PR TITLE
Updated to follow current guidance

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports = function(source, inputSourceMap) {
       this.cacheable();
     }
 
-    var opts = this.options['uglify-loader'] || {};
+    var opts = loaderUtils.getOptions(this) || {};
     // just an indicator to generate source maps, the output result.map will be modified anyway
     // tell UglifyJS2 not to emit a name by just setting outSourceMap to true
     opts.outSourceMap = true;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/bestander/uglify-loader",
   "dependencies": {
-    "loader-utils": "^0.2.7",
+    "loader-utils": "^1.0.2",
     "source-map": "^0.5.6"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uglify-loader",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "description": "Uglify.js loader for webpack",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   "homepage": "https://github.com/bestander/uglify-loader",
   "dependencies": {
     "loader-utils": "^0.2.7",
-    "source-map": "^0.5.6",
+    "source-map": "^0.5.6"
+  },
+  "peerDependencies": {
     "uglify-js": "^2.4.16"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uglify-loader",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Uglify.js loader for webpack",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Two significant changes here:

* Getting options via `loaderUtils.getOptions(this)` instead of `this.options['uglify-loader']` (requires loader-utils > 1.0)
  * This enables the use of function rules (a la [uglify-save-license](https://github.com/shinnn/uglify-save-license)) when combined with the new `ident` feature in webpack 2
* Moved `uglify-js` to peerDependencies
  * This makes the package more in line with the official webpack suggestions for writing loaders. See [how to write a loader](https://webpack.js.org/development/how-to-write-a-loader/#use-a-library-as-peerdependencies-when-they-wrap-it).
  * This requires a major version bump on the package because it breaks existing users.