### PR TITLE
Upgrade uglify.js and bump other pkgs

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,8 +48,7 @@ module.exports = function(source, inputSourceMap) {
     var opts = loaderUtils.getOptions(this) || {};
     // just an indicator to generate source maps, the output result.map will be modified anyway
     // tell UglifyJS2 not to emit a name by just setting outSourceMap to true
-    opts.outSourceMap = true;
-    opts.fromString = true;
+    opts.sourceMap = true;
 
     var result = UglifyJS.minify(source, opts);
     var sourceMap = JSON.parse(result.map);

--- a/package.json
+++ b/package.json
@@ -21,10 +21,8 @@
   },
   "homepage": "https://github.com/bestander/uglify-loader",
   "dependencies": {
-    "loader-utils": "^1.0.2",
-    "source-map": "^0.5.6"
-  },
-  "peerDependencies": {
-    "uglify-js": "^2.4.16"
+    "loader-utils": "^1.1.0",
+    "source-map": "^0.7.3",
+    "uglify-js": "^3.4.8"
   }
 }


### PR DESCRIPTION
We use the `uglify-js` for generating codes, peer dependency may conflict with other packages also declared `uglify-js` as `peerDependencies`.

`uglify-js 3` doesn't allow extra options and renamed the `outSourceMap` option as `sourceMap`